### PR TITLE
kramdown: fix state leakage (#30) in test

### DIFF
--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -14,6 +14,7 @@ class TestKramdown < BuntoUnitTest
           'auto_ids' => false,
           'footnote_nr' => 1,
 
+          'syntax_highlighter' => 'rouge',
           'syntax_highlighter_opts' => {
             'bold_every' => 8, 'css' => :class
           }


### PR DESCRIPTION
The tests for Bunto are full of state leakage, e.g. #30. If you keep running the tests, you will surely see some failures, even if it eventually all passes. To prevent this, never assume the order tests will be run in, make sure the test could run on it's own and after any other tests.
