### PR TITLE
Update links to point to core Liquid site

### DIFF
--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -4,9 +4,9 @@ title: Templates
 permalink: /docs/templates/
 ---
 
-Bunto uses the [Liquid](https://github.com/Shopify/liquid/wiki) templating language to
-process templates. All of the standard Liquid [tags](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers#tags) and
-[filters](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers#standard-filters) are
+Bunto uses the [Liquid](https://shopify.github.io/liquid/) templating language to
+process templates. All of the standard Liquid [tags](https://shopify.github.io/liquid/tags/) and
+[filters](https://shopify.github.io/liquid/filters/) are
 supported. Bunto even adds a few handy filters and tags of its own to make
 common tasks easier.
 


### PR DESCRIPTION
This updates the links at the top of the Templates page to point to the new shopify.github.io/liquid website, including the index pages for tags and filters added in Shopify/liquid#765.
