### PR TITLE
Add Slack notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,9 @@ branches:
     - 3.2.1
 
 notifications:
+notifications:
+  slack:
+    secure: YZjawNDiMMMVPCIH+Z00wBr39Qftdia1Uq+CaaPPe8xYRzDi9gOowvnmfkjDQE8PIuHMVtuAF6L3yO8gHrCVnf3aKkj/frYNOgLmtkTr3xSbP/OvmWalS9Y4R/LpGIfKaUG/GE5hW6ZULbiB2ou5yOloWfeSBze5f1JWjyJrHao=
   email:
     recipients:
       - SuriyaaKudoIsc@users.noreply.github.com


### PR DESCRIPTION
Add the Slack notification for Travis CI.

---

``` powershell
C:\Users\Suriyaa\Documents\GitHub\bunto [slack ≡ +0 ~1 -0 !]> gem install travis
Fetching: faraday_middleware-0.10.0.gem (100%)
Successfully installed faraday_middleware-0.10.0
Fetching: backports-3.6.8.gem (100%)
Successfully installed backports-3.6.8
Fetching: connection_pool-2.2.0.gem (100%)
Successfully installed connection_pool-2.2.0
Fetching: net-http-persistent-3.0.0.gem (100%)
Successfully installed net-http-persistent-3.0.0
Fetching: net-http-pipeline-1.0.1.gem (100%)
Successfully installed net-http-pipeline-1.0.1
Fetching: gh-0.14.0.gem (100%)
Successfully installed gh-0.14.0
Fetching: ethon-0.9.1.gem (100%)
Successfully installed ethon-0.9.1
Fetching: typhoeus-0.8.0.gem (100%)
Successfully installed typhoeus-0.8.0
Fetching: websocket-1.2.3.gem (100%)
Successfully installed websocket-1.2.3
Fetching: pusher-client-0.6.2.gem (100%)
Successfully installed pusher-client-0.6.2
Fetching: travis-1.8.2.gem (100%)
Successfully installed travis-1.8.2
Parsing documentation for faraday_middleware-0.10.0
Installing ri documentation for faraday_middleware-0.10.0
Parsing documentation for backports-3.6.8
Installing ri documentation for backports-3.6.8
Parsing documentation for connection_pool-2.2.0
Installing ri documentation for connection_pool-2.2.0
Parsing documentation for net-http-persistent-3.0.0
Installing ri documentation for net-http-persistent-3.0.0
Parsing documentation for net-http-pipeline-1.0.1
Installing ri documentation for net-http-pipeline-1.0.1
Parsing documentation for gh-0.14.0
Installing ri documentation for gh-0.14.0
Parsing documentation for ethon-0.9.1
Installing ri documentation for ethon-0.9.1
Parsing documentation for typhoeus-0.8.0
Installing ri documentation for typhoeus-0.8.0
Parsing documentation for websocket-1.2.3
Installing ri documentation for websocket-1.2.3
Parsing documentation for pusher-client-0.6.2
Installing ri documentation for pusher-client-0.6.2
Parsing documentation for travis-1.8.2
Installing ri documentation for travis-1.8.2
Done installing documentation for faraday_middleware, backports, connection_pool, net-http-persistent, net-http-pipeline, gh, ethon, typhoeus, websocket, pusher-client, travis after 54 seconds
11 gems installed
C:\Users\Suriyaa\Documents\GitHub\bunto [slack ≡ +0 ~1 -0 !]> travis encrypt "bunto:<secret integration token>" --add notifications.slack
Detected repository as bunto/bunto, is this correct? |yes| yes
C:\Users\Suriyaa\Documents\GitHub\bunto [slack ≡ +0 ~1 -0 !]> git status
On branch slack
Your branch is up-to-date with 'origin/slack'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        modified:   .travis.yml

no changes added to commit (use "git add" and/or "git commit -a")
C:\Users\Suriyaa\Documents\GitHub\bunto [slack ≡ +0 ~1 -0 !]> git add *
C:\Users\Suriyaa\Documents\GitHub\bunto [slack ≡ +0 ~1 -0 ~]> git status
On branch slack
Your branch is up-to-date with 'origin/slack'.
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        modified:   .travis.yml

C:\Users\Suriyaa\Documents\GitHub\bunto [slack ≡ +0 ~1 -0 ~]> git commit -S -m "Add Slack notification"

Sie benötigen eine Passphrase, um den geheimen Schlüssel zu entsperren.
Benutzer: "suriyaa <isc.suriyaa@gmail.com>"
2048-Bit RSA Schlüssel, ID FDDD96B0, erzeugt 2016-04-08

[slack bdbcadb] Add Slack notification
 1 file changed, 3 insertions(+)
C:\Users\Suriyaa\Documents\GitHub\bunto [slack ↑]> git push
Counting objects: 3, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 882 bytes | 0 bytes/s, done.
Total 3 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To https://github.com/bunto/bunto.git
   d96baa7..bdbcadb  slack -> slack
C:\Users\Suriyaa\Documents\GitHub\bunto [slack ≡]>
```
